### PR TITLE
Update top left navigation with logo

### DIFF
--- a/src/components/defaultNavbar.tsx
+++ b/src/components/defaultNavbar.tsx
@@ -210,14 +210,12 @@ export default function Example() {
     <ThemeProvider>
       <Navbar className="absolute mx-auto left-0 right-0 top-3 max-w-screen-xl px-4 py-2 z-10">
         <div className="flex items-center justify-between text-blue-gray-900">
-          <Typography
-            as="a"
-            href="/astro-launch-ui/"
-            variant="h6"
-            className="mr-4 cursor-pointer py-1.5 lg:ml-2"
-          >
-            AstroLaunch UI
-          </Typography>
+          <img
+            src="https://www.pngall.com/wp-content/uploads/13/Adobe-Logo-PNG-Picture.png"
+            alt="Adobe Logo"
+            className="mr-4 cursor-pointer py-1.5 lg:ml-2 h-8"
+            onClick={() => window.location.href = "/astro-launch-ui/"}
+          />
           <div className="hidden lg:block">
             <NavList />
           </div>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -318,13 +318,12 @@ export default function ComplexNavbar() {
       }`}
     >
       <div className="relative mx-auto flex items-center text-blue-gray-900">
-        <Typography
-          as="a"
-          href="/"
-          className="mr-4 ml-2 cursor-pointer py-1.5 font-medium"
-        >
-          AstroLaunch UI
-        </Typography>
+        <img
+          src="https://www.pngall.com/wp-content/uploads/13/Adobe-Logo-PNG-Picture.png"
+          alt="Adobe Logo"
+          className="mr-4 ml-2 cursor-pointer py-1.5 h-8"
+          onClick={() => window.location.href = "/"}
+        />
         <div className="hidden lg:flex ml-auto">
           <NavList />
         </div>


### PR DESCRIPTION
I modified two navigation components to replace the "AstroLaunch UI" text with the Adobe logo.

*   In `src/components/defaultNavbar.tsx` and `src/components/navbar.tsx`, I removed the existing `Typography` component that displayed "AstroLaunch UI".
*   I then added an `<img>` element in its place, using the provided URL `https://www.pngall.com/wp-content/uploads/13/Adobe-Logo-PNG-Picture.png` for the `src` attribute.
*   To maintain accessibility, I included an `alt="Adobe Logo"` attribute.
*   I preserved the original styling and positioning by transferring relevant CSS classes like `mr-4`, `ml-2`, `cursor-pointer`, and `py-1.5` to the new `<img>` tag.
*   I added an `h-8` class to ensure the logo had an appropriate and consistent height within the navigation bar.
*   Finally, I implemented an `onClick` handler on the `<img>` element to replicate the original navigation behavior, directing users to the respective home pages (`/astro-launch-ui/` for `defaultNavbar.tsx` and `/` for `navbar.tsx`) when the logo is clicked.