### PR TITLE
Add logo to top left navigation

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -318,13 +318,16 @@ export default function ComplexNavbar() {
       }`}
     >
       <div className="relative mx-auto flex items-center text-blue-gray-900">
-        <Typography
-          as="a"
+        <a
           href="/"
-          className="mr-4 ml-2 cursor-pointer py-1.5 font-medium"
+          className="mr-4 ml-2 cursor-pointer py-1.5"
         >
-          AstroLaunch UI
-        </Typography>
+          <img 
+            src="https://www.pngall.com/wp-content/uploads/13/Adobe-Logo-PNG-Picture.png" 
+            alt="Adobe Logo" 
+            className="h-8 w-auto object-contain"
+          />
+        </a>
         <div className="hidden lg:flex ml-auto">
           <NavList />
         </div>


### PR DESCRIPTION
The top-left navigation in `src/components/navbar.tsx` was updated to display a logo instead of text.

Specifically:
*   The `Typography` component containing "AstroLaunch UI" was replaced.
*   An `<img>` element was introduced within the `<a>` tag, using the provided Adobe logo URL.
*   The `alt` attribute was set to "Adobe Logo" for accessibility.
*   Tailwind CSS classes (`h-8 w-auto object-contain`) were applied to the `<img>` tag to ensure the logo is responsive, maintains its aspect ratio, and fits within its container.

These changes ensure the logo is correctly displayed, replaces the old text, and maintains the original clickable functionality linking to the home page.