### PR TITLE
Add logo to top left navigation

### DIFF
--- a/src/components/defaultNavbar.tsx
+++ b/src/components/defaultNavbar.tsx
@@ -210,14 +210,16 @@ export default function Example() {
     <ThemeProvider>
       <Navbar className="absolute mx-auto left-0 right-0 top-3 max-w-screen-xl px-4 py-2 z-10">
         <div className="flex items-center justify-between text-blue-gray-900">
-          <Typography
-            as="a"
+          <a
             href="/astro-launch-ui/"
-            variant="h6"
-            className="mr-4 cursor-pointer py-1.5 lg:ml-2"
+            className="mr-4 cursor-pointer py-1.5 lg:ml-2 flex items-center"
           >
-            AstroLaunch UI
-          </Typography>
+            <img 
+              src="https://www.pngall.com/wp-content/uploads/13/Adobe-Logo-PNG-Picture.png"
+              alt="Adobe Logo"
+              className="h-8 w-auto"
+            />
+          </a>
           <div className="hidden lg:block">
             <NavList />
           </div>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -318,13 +318,16 @@ export default function ComplexNavbar() {
       }`}
     >
       <div className="relative mx-auto flex items-center text-blue-gray-900">
-        <Typography
-          as="a"
+        <a
           href="/"
-          className="mr-4 ml-2 cursor-pointer py-1.5 font-medium"
+          className="mr-4 ml-2 cursor-pointer py-1.5 flex items-center"
         >
-          AstroLaunch UI
-        </Typography>
+          <img 
+            src="https://www.pngall.com/wp-content/uploads/13/Adobe-Logo-PNG-Picture.png"
+            alt="Adobe Logo"
+            className="h-8 w-auto"
+          />
+        </a>
         <div className="hidden lg:flex ml-auto">
           <NavList />
         </div>


### PR DESCRIPTION
The top-left navigation text "AstroLaunch UI" was replaced with an Adobe logo across two primary navigation components:
*   `src/components/defaultNavbar.tsx`
*   `src/components/navbar.tsx`

The `<Typography>` component wrapping the navigation link was replaced with a standard `<a>` tag. An `<img>` tag was inserted within the `<a>` tag, using the provided URL `https://www.pngall.com/wp-content/uploads/13/Adobe-Logo-PNG-Picture.png` and appropriate `alt` text.

Styling was applied using Tailwind CSS classes:
*   `h-8 w-auto` was added to the `<img>` tag to set a fixed height of 32px while maintaining the aspect ratio.
*   `flex items-center` was added to the `<a>` tag to ensure vertical centering of the logo within the navigation bar.

These changes ensure the logo is properly sized, responsive, and consistently displayed on all pages utilizing these navigation components, including landing, 404, login/signup, presentation, and about pages.