### PR TITLE
Add logo to top left navigation

### DIFF
--- a/src/components/defaultNavbar.tsx
+++ b/src/components/defaultNavbar.tsx
@@ -210,14 +210,16 @@ export default function Example() {
     <ThemeProvider>
       <Navbar className="absolute mx-auto left-0 right-0 top-3 max-w-screen-xl px-4 py-2 z-10">
         <div className="flex items-center justify-between text-blue-gray-900">
-          <Typography
-            as="a"
+          <a
             href="/astro-launch-ui/"
-            variant="h6"
             className="mr-4 cursor-pointer py-1.5 lg:ml-2"
           >
-            AstroLaunch UI
-          </Typography>
+            <img 
+              src="https://www.pngall.com/wp-content/uploads/13/Adobe-Logo-PNG-Picture.png" 
+              alt="Adobe Logo" 
+              className="h-8 w-auto"
+            />
+          </a>
           <div className="hidden lg:block">
             <NavList />
           </div>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -318,13 +318,16 @@ export default function ComplexNavbar() {
       }`}
     >
       <div className="relative mx-auto flex items-center text-blue-gray-900">
-        <Typography
-          as="a"
+        <a
           href="/"
-          className="mr-4 ml-2 cursor-pointer py-1.5 font-medium"
+          className="mr-4 ml-2 cursor-pointer py-1.5"
         >
-          AstroLaunch UI
-        </Typography>
+          <img 
+            src="https://www.pngall.com/wp-content/uploads/13/Adobe-Logo-PNG-Picture.png" 
+            alt="Adobe Logo" 
+            className="h-8 w-auto"
+          />
+        </a>
         <div className="hidden lg:flex ml-auto">
           <NavList />
         </div>


### PR DESCRIPTION
The top-left navigation text was replaced with an Adobe logo across multiple navigation components.

*   In `src/components/navbar.tsx` and `src/components/defaultNavbar.tsx`, the `Typography` component displaying "AstroLaunch UI" was replaced.
*   An `<img>` element, sourced from `https://www.pngall.com/wp-content/uploads/13/Adobe-Logo-PNG-Picture.png`, was inserted within an `<a>` tag.
*   The `<img>` was styled with `h-8 w-auto` to ensure proper sizing and responsiveness.

This modification ensures the specified Adobe logo is consistently displayed in the top-left navigation across all pages utilizing these components, replacing the previous text.